### PR TITLE
Enemy-Enemy Collisions not longer cause fixture to become players fixture

### DIFF
--- a/core/src/com/dev/flying/kiwi/gamecore/collisions/ContactController.java
+++ b/core/src/com/dev/flying/kiwi/gamecore/collisions/ContactController.java
@@ -14,16 +14,6 @@ import com.dev.flying.kiwi.gamecore.components.PlayerComponent;
 public class ContactController implements ContactListener {
     @Override
     public void beginContact(Contact contact) {
-
-    }
-
-    @Override
-    public void endContact(Contact contact) {
-
-    }
-
-    @Override
-    public void preSolve(Contact contact, Manifold oldManifold) {
         Fixture dataA = contact.getFixtureA();
         Fixture dataB = contact.getFixtureB();
 
@@ -45,6 +35,16 @@ public class ContactController implements ContactListener {
                 }
             }
         }
+    }
+
+    @Override
+    public void endContact(Contact contact) {
+
+    }
+
+    @Override
+    public void preSolve(Contact contact, Manifold oldManifold) {
+
     }
 
     @Override

--- a/core/src/com/dev/flying/kiwi/gamecore/collisions/ContactController.java
+++ b/core/src/com/dev/flying/kiwi/gamecore/collisions/ContactController.java
@@ -3,7 +3,6 @@ package com.dev.flying.kiwi.gamecore.collisions;
 import com.badlogic.ashley.core.Entity;
 import com.badlogic.gdx.physics.box2d.*;
 import com.dev.flying.kiwi.gamecore.components.CollidedEnemyComponent;
-import com.dev.flying.kiwi.gamecore.components.EnemyComponent;
 import com.dev.flying.kiwi.gamecore.components.PlayerComponent;
 
 /**
@@ -15,13 +14,7 @@ import com.dev.flying.kiwi.gamecore.components.PlayerComponent;
 public class ContactController implements ContactListener {
     @Override
     public void beginContact(Contact contact) {
-        Fixture dataA = contact.getFixtureA();
-        Fixture dataB = contact.getFixtureB();
 
-        if(validateFixture(dataA) && validateFixture(dataB) ) {
-            processFixture(dataA);
-            processFixture(dataB);
-        }
     }
 
     @Override
@@ -31,7 +24,27 @@ public class ContactController implements ContactListener {
 
     @Override
     public void preSolve(Contact contact, Manifold oldManifold) {
+        Fixture dataA = contact.getFixtureA();
+        Fixture dataB = contact.getFixtureB();
 
+        if(validateFixture(dataA) && validateFixture(dataB) ) {
+            Entity entityA = (Entity) dataA.getBody().getUserData();
+            Entity entityB = (Entity) dataB.getBody().getUserData();
+
+            boolean isAPlayer = isPlayer(entityA);
+            boolean isBPlayer = isPlayer(entityB);
+
+            if(isAPlayer || isBPlayer) { // Must has player in one of them else do nothing.
+
+                // Add a CollidedEnemyComponent to the not-player entity
+                if(!isAPlayer) {
+                    entityA.add(new CollidedEnemyComponent());
+                }
+                if(!isBPlayer) {
+                    entityB.add(new CollidedEnemyComponent());
+                }
+            }
+        }
     }
 
     @Override
@@ -43,17 +56,12 @@ public class ContactController implements ContactListener {
         return f != null && f.getBody().getUserData() != null && f.getBody().getUserData() instanceof Entity;
     }
 
-    void processFixture(Fixture data) {
-        Entity entity = (Entity) data.getBody().getUserData();
-
-        if(entity != null) {
-            if (entity.getComponent(PlayerComponent.class) != null) {
-                // entity is the player, so do nothing
-
-            } else if( entity.getComponent(EnemyComponent.class) != null) {
-                entity.add(new CollidedEnemyComponent());
-
-            }
-        }
+    /**
+     * Returns if Entity is a player entity
+     * @param a Entity A
+     * @return boolean true if the entity is player, else false
+     */
+    private boolean isPlayer(Entity a) {
+        return a.getComponent(PlayerComponent.class) != null;
     }
 }


### PR DESCRIPTION
Changed collision processing so only enemy>player (or vice-versa) cause the fixture to be added to the player.
