### PR TITLE
Add textures 

### DIFF
--- a/core/src/com/dev/flying/kiwi/gamecore/actors/ShapeActor.java
+++ b/core/src/com/dev/flying/kiwi/gamecore/actors/ShapeActor.java
@@ -1,6 +1,5 @@
 package com.dev.flying.kiwi.gamecore.actors;
 
-import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.Batch;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.scenes.scene2d.Actor;
@@ -19,8 +18,7 @@ public class ShapeActor extends Actor {
 
     @Override
     public void draw(Batch batch, float parentAlpha) {
-        Color color = getColor();
-        batch.setColor(color.r, color.g, color.b, color.a * parentAlpha);
+        batch.setColor(getColor().r, getColor().g, getColor().b, getColor().a * parentAlpha);
         batch.draw(this.textureRegion, getX() - getWidth()/2, getY() - getHeight()/2, getOriginX(), getOriginY(),
                 getWidth(), getHeight(), getScaleX(), getScaleY(), getRotation());
     }

--- a/core/src/com/dev/flying/kiwi/gamecore/actors/ShapeActor.java
+++ b/core/src/com/dev/flying/kiwi/gamecore/actors/ShapeActor.java
@@ -21,7 +21,7 @@ public class ShapeActor extends Actor {
     public void draw(Batch batch, float parentAlpha) {
         Color color = getColor();
         batch.setColor(color.r, color.g, color.b, color.a * parentAlpha);
-        batch.draw(this.textureRegion, getX(), getY(), getOriginX(), getOriginY(),
+        batch.draw(this.textureRegion, getX() - getWidth()/2, getY() - getHeight()/2, getOriginX(), getOriginY(),
                 getWidth(), getHeight(), getScaleX(), getScaleY(), getRotation());
     }
 }

--- a/core/src/com/dev/flying/kiwi/gamecore/actors/ShapeActorFactory.java
+++ b/core/src/com/dev/flying/kiwi/gamecore/actors/ShapeActorFactory.java
@@ -19,7 +19,7 @@ import java.util.Random;
  */
 public class ShapeActorFactory {
     public enum Shapes {
-        CIRCLE ("hex/player_circle.png"),
+        CIRCLE ("hex/glow-circle.png"),
         RECT ("hex/player_rect.png"),
         HEX ("hex/player_hex.png"),
         PENTAGON ("hex/player_pent.png");
@@ -51,8 +51,7 @@ public class ShapeActorFactory {
         shape.setRotation(0);
         shape.setWidth(size.x);
         shape.setHeight(size.y);
-
-        shape.setColor(Color.BLACK);
+        shape.setColor(Color.WHITE);
         shape.setBounds(0, 0, shape.getWidth(), shape.getHeight());
         shape.setOrigin(shape.getWidth() / 2, shape.getHeight() / 2);
         return shape;

--- a/core/src/com/dev/flying/kiwi/gamecore/actors/ShapeActorFactory.java
+++ b/core/src/com/dev/flying/kiwi/gamecore/actors/ShapeActorFactory.java
@@ -1,9 +1,10 @@
 package com.dev.flying.kiwi.gamecore.actors;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
-import com.badlogic.gdx.scenes.scene2d.Actor;
+import com.badlogic.gdx.math.Vector2;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -44,11 +45,14 @@ public class ShapeActorFactory {
      * @param s The shape in which to use a the texture
      * @return The Actor
      */
-    public static Actor generateSpecificShape(Shapes s) {
-        Actor shape = new ShapeActor(new TextureRegion(new Texture(Gdx.files.internal(s.value))));
+    public static ShapeActor generateSpecificShape(Shapes s, Vector2 size) {
+        TextureRegion tr = new TextureRegion(new Texture(Gdx.files.internal(s.value)));
+        ShapeActor shape = new ShapeActor(tr);
         shape.setRotation(0);
-        shape.setWidth(64);
-        shape.setHeight(64);
+        shape.setWidth(size.x);
+        shape.setHeight(size.y);
+
+        shape.setColor(Color.BLACK);
         shape.setBounds(0, 0, shape.getWidth(), shape.getHeight());
         shape.setOrigin(shape.getWidth() / 2, shape.getHeight() / 2);
         return shape;
@@ -58,7 +62,7 @@ public class ShapeActorFactory {
      * A random shaped actor
      * @return an Actor
      */
-    public static Actor generateShape() {
-       return generateSpecificShape(Shapes.randomShape());
+    public static ShapeActor generateShape(Vector2 size) {
+       return generateSpecificShape(Shapes.randomShape(), size);
     }
 }

--- a/core/src/com/dev/flying/kiwi/gamecore/components/ActorComponent.java
+++ b/core/src/com/dev/flying/kiwi/gamecore/components/ActorComponent.java
@@ -1,7 +1,7 @@
 package com.dev.flying.kiwi.gamecore.components;
 
 import com.badlogic.ashley.core.Component;
-import com.badlogic.gdx.scenes.scene2d.Actor;
+import com.dev.flying.kiwi.gamecore.actors.ShapeActor;
 
 /**
  * ActorComponent
@@ -9,9 +9,9 @@ import com.badlogic.gdx.scenes.scene2d.Actor;
  * Created by Steven on 9/23/2015.
  */
 public class ActorComponent implements Component {
-    public Actor actor;
+    public ShapeActor actor;
 
-    public ActorComponent(Actor actor) {
+    public ActorComponent(ShapeActor actor) {
         this.actor = actor;
     }
 }

--- a/core/src/com/dev/flying/kiwi/gamecore/prefabs/EnemyCreator.java
+++ b/core/src/com/dev/flying/kiwi/gamecore/prefabs/EnemyCreator.java
@@ -2,9 +2,10 @@ package com.dev.flying.kiwi.gamecore.prefabs;
 
 import com.badlogic.ashley.core.Entity;
 import com.badlogic.ashley.core.PooledEngine;
+import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.physics.box2d.*;
-import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.dev.flying.kiwi.gamecore.actors.ShapeActor;
 import com.dev.flying.kiwi.gamecore.actors.ShapeActorFactory;
 import com.dev.flying.kiwi.gamecore.components.ActorComponent;
 import com.dev.flying.kiwi.gamecore.components.Box2DBodyComponent;
@@ -25,7 +26,7 @@ public class EnemyCreator extends GameObjectCreator {
     @Override
     public Entity create(float x, float y) {
         Entity enemy = engine.createEntity();
-        Actor actor = ShapeActorFactory.generateShape();
+        ShapeActor actor = ShapeActorFactory.generateShape(new Vector2(1.5f,1.5f));
         Body body = EnemyCreator.createEnemy(world, x, y);
         body.setUserData(enemy);
 

--- a/core/src/com/dev/flying/kiwi/gamecore/prefabs/PlayerCreator.java
+++ b/core/src/com/dev/flying/kiwi/gamecore/prefabs/PlayerCreator.java
@@ -2,9 +2,10 @@ package com.dev.flying.kiwi.gamecore.prefabs;
 
 import com.badlogic.ashley.core.Entity;
 import com.badlogic.ashley.core.PooledEngine;
+import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.physics.box2d.*;
-import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.dev.flying.kiwi.gamecore.actors.ShapeActor;
 import com.dev.flying.kiwi.gamecore.actors.ShapeActorFactory;
 import com.dev.flying.kiwi.gamecore.components.ActorComponent;
 import com.dev.flying.kiwi.gamecore.components.Box2DBodyComponent;
@@ -24,7 +25,7 @@ public class PlayerCreator extends GameObjectCreator {
     @Override
     public Entity create(float x, float y) {
         Entity player = engine.createEntity();
-        Actor playerActor = ShapeActorFactory.generateSpecificShape(ShapeActorFactory.Shapes.HEX);
+        ShapeActor playerActor = ShapeActorFactory.generateSpecificShape(ShapeActorFactory.Shapes.HEX, new Vector2(2,2));
         playerActor.setName("Player");
         Body body = PlayerCreator.createPlayer(world);
         body.setUserData(player);

--- a/core/src/com/dev/flying/kiwi/gamecore/prefabs/PlayerCreator.java
+++ b/core/src/com/dev/flying/kiwi/gamecore/prefabs/PlayerCreator.java
@@ -2,6 +2,7 @@ package com.dev.flying.kiwi.gamecore.prefabs;
 
 import com.badlogic.ashley.core.Entity;
 import com.badlogic.ashley.core.PooledEngine;
+import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.physics.box2d.*;
 import com.badlogic.gdx.scenes.scene2d.Stage;
@@ -25,8 +26,9 @@ public class PlayerCreator extends GameObjectCreator {
     @Override
     public Entity create(float x, float y) {
         Entity player = engine.createEntity();
-        ShapeActor playerActor = ShapeActorFactory.generateSpecificShape(ShapeActorFactory.Shapes.HEX, new Vector2(2,2));
+        ShapeActor playerActor = ShapeActorFactory.generateSpecificShape(ShapeActorFactory.Shapes.CIRCLE, new Vector2(2,2));
         playerActor.setName("Player");
+        playerActor.setColor(Color.GREEN);
         Body body = PlayerCreator.createPlayer(world);
         body.setUserData(player);
 

--- a/core/src/com/dev/flying/kiwi/gamecore/screens/PlayScreen.java
+++ b/core/src/com/dev/flying/kiwi/gamecore/screens/PlayScreen.java
@@ -20,9 +20,9 @@ import com.dev.flying.kiwi.gamecore.input.PlayerMouseMoveController;
 import com.dev.flying.kiwi.gamecore.prefabs.EnemyCreator;
 import com.dev.flying.kiwi.gamecore.prefabs.PlayerCreator;
 import com.dev.flying.kiwi.gamecore.prefabs.SpawnerCreator;
+import com.dev.flying.kiwi.gamecore.systems.BodyActorUpdateSystem;
 import com.dev.flying.kiwi.gamecore.systems.EnemyCleanupSystem;
 import com.dev.flying.kiwi.gamecore.systems.EnemyMovementSystem;
-import com.dev.flying.kiwi.gamecore.systems.PhysicsActorRenderSystem;
 import com.dev.flying.kiwi.gamecore.systems.SpawnSystem;
 
 /**
@@ -46,12 +46,14 @@ public class PlayScreen implements Screen {
 
     private Entity player;
     private PooledEngine engine;
-    private PhysicsActorRenderSystem physicsActorRenderSystem;
+    private BodyActorUpdateSystem bodyActorUpdateSystem;
     private EnemyCleanupSystem enemyCleanupSystem;
 
     @Override
     public void show() {
         engine = new PooledEngine();
+
+        /** TODO Stage should own camera and  batch call {@link Stage#getCamera()} {@link Stage#getBatch()}  */
         stage = new Stage(new StretchViewport(Gdx.graphics.getWidth(), Gdx.graphics.getHeight()));
 
         camera = new OrthographicCamera(Gdx.graphics.getWidth() / 25, Gdx.graphics.getHeight() / 25);
@@ -84,8 +86,8 @@ public class PlayScreen implements Screen {
 
     private void ashleySystems() {
         // Renders sprites to the Box2D Body/Fixture locations
-        physicsActorRenderSystem = new PhysicsActorRenderSystem(batch);
-        engine.addSystem(physicsActorRenderSystem);
+        bodyActorUpdateSystem = new BodyActorUpdateSystem();
+        engine.addSystem(bodyActorUpdateSystem);
 
         // Updates the location of enemies
         engine.addSystem(new EnemyMovementSystem(Vector2.Zero));
@@ -111,8 +113,9 @@ public class PlayScreen implements Screen {
     private void draw(float delta) {
         batch.setProjectionMatrix(camera.combined);
 
+        // TODO Use stage to call {@link stage#draw()}
         batch.begin();
-        physicsActorRenderSystem.drawRenderQueue();
+        bodyActorUpdateSystem.drawRenderQueue(batch);
         batch.end();
 
         debugRenderer.render(world, camera.combined);

--- a/core/src/com/dev/flying/kiwi/gamecore/screens/PlayScreen.java
+++ b/core/src/com/dev/flying/kiwi/gamecore/screens/PlayScreen.java
@@ -78,15 +78,19 @@ public class PlayScreen implements Screen {
     }
 
     private void userInput() {
-
         InputMultiplexer im = new InputMultiplexer(new PlayerMouseMoveController(player), stage);
         Gdx.input.setInputProcessor(im);
     }
 
     private void ashleySystems() {
+        // Renders sprites to the Box2D Body/Fixture locations
         physicsActorRenderSystem = new PhysicsActorRenderSystem(batch);
         engine.addSystem(physicsActorRenderSystem);
+
+        // Updates the location of enemies
         engine.addSystem(new EnemyMovementSystem(Vector2.Zero));
+
+        // Switches enemies to be a part of the player on collision
         enemyCleanupSystem = new EnemyCleanupSystem(world, engine, player.getComponent(Box2DBodyComponent.class).body);
         engine.addSystem(enemyCleanupSystem);
 
@@ -105,10 +109,13 @@ public class PlayScreen implements Screen {
     }
 
     private void draw(float delta) {
-        debugRenderer.render(world, camera.combined);
+        batch.setProjectionMatrix(camera.combined);
+
         batch.begin();
         physicsActorRenderSystem.drawRenderQueue();
         batch.end();
+
+        debugRenderer.render(world, camera.combined);
     }
 
     @Override

--- a/core/src/com/dev/flying/kiwi/gamecore/systems/BodyActorUpdateSystem.java
+++ b/core/src/com/dev/flying/kiwi/gamecore/systems/BodyActorUpdateSystem.java
@@ -5,8 +5,10 @@ import com.badlogic.ashley.core.Entity;
 import com.badlogic.ashley.core.Family;
 import com.badlogic.ashley.systems.IteratingSystem;
 import com.badlogic.gdx.graphics.g2d.Batch;
-import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.math.MathUtils;
+import com.badlogic.gdx.physics.box2d.Body;
 import com.badlogic.gdx.utils.Array;
+import com.dev.flying.kiwi.gamecore.actors.ShapeActor;
 import com.dev.flying.kiwi.gamecore.components.ActorComponent;
 import com.dev.flying.kiwi.gamecore.components.Box2DBodyComponent;
 
@@ -14,33 +16,39 @@ import com.dev.flying.kiwi.gamecore.components.Box2DBodyComponent;
  * This system renders sprites at a position based on the world, for a given actor.
  * Created by Steven on 9/23/2015.
  */
-public class PhysicsActorRenderSystem extends IteratingSystem {
+public class BodyActorUpdateSystem extends IteratingSystem {
     private ComponentMapper<Box2DBodyComponent> physicsMapper;
     private ComponentMapper<ActorComponent> actorMapper;
 
-    private Array<Entity> renderQueue;
-    private Batch batch;
+    private Array<Entity> entitiesToUpdate;
 
-    public PhysicsActorRenderSystem(Batch batch) {
+    public BodyActorUpdateSystem() {
         super(Family.all(Box2DBodyComponent.class, ActorComponent.class).get());
         this.physicsMapper = ComponentMapper.getFor(Box2DBodyComponent.class);
         this.actorMapper = ComponentMapper.getFor(ActorComponent.class);
-        this.renderQueue = new Array<>();
+        this.entitiesToUpdate = new Array<>();
     }
 
     @Override
     protected void processEntity(Entity entity, float deltaTime) {
-        renderQueue.add(entity);
+        entitiesToUpdate.add(entity);
     }
 
-    public void drawRenderQueue() {
-        TextureRegion tr;
-//        for (Entity e : this.renderQueue) {
-//            tr = new TextureRegion(drawableMapper.get(e).texture, 0, 0, 64,64);
-//            batch.draw(tr, positionMapper.get(e).x, positionMapper.get(e).y, positionMapper.get(e).x, positionMapper.get(e).y, 32f, 32f, 1.0f, 1.0f, 10f);
-//            //batch.draw(drawableMapper.get(e).texture, positionMapper.get(e).x, positionMapper.get(e).y);
-//        }
-        renderQueue.clear();
+    public void drawRenderQueue(Batch batch) {
+        ShapeActor actor;
+        Body body;
+
+        for (Entity e : this.entitiesToUpdate) {
+            actor = actorMapper.get(e).actor;
+            body = physicsMapper.get(e).body;
+
+            actor.setPosition(body.getPosition().x, body.getPosition().y);
+            actor.setRotation(MathUtils.radiansToDegrees * body.getAngle());
+
+            actor.draw(batch, 1);
+        }
+
+        entitiesToUpdate.clear();
     }
 
 

--- a/core/src/com/dev/flying/kiwi/gamecore/systems/SpawnSystem.java
+++ b/core/src/com/dev/flying/kiwi/gamecore/systems/SpawnSystem.java
@@ -42,7 +42,10 @@ public class SpawnSystem extends IntervalSystem {
 
     @Override
     protected void updateInterval() {
-        Entity spawner = randomSpawner();
-        toSpawn.create(pm.get(spawner).x, pm.get(spawner).y);
+        if(entities.size() > 0) {
+            Entity spawner = randomSpawner();
+
+            toSpawn.create(pm.get(spawner).x, pm.get(spawner).y);
+        }
     }
 }


### PR DESCRIPTION
Sets the game to use ShapeActors which own a TextureRegion, and can render this.
Repurposes the PhysicsActorRenderSystem to be for Updating (& rendering) the Actors location, with the intention that stage.draw() can then render these sprites once this is implemented.

![image](https://cloud.githubusercontent.com/assets/2215023/10156213/1da27b0a-66db-11e5-98d4-f061989c7bb7.png)

Exposed bug: on impact with the player the enemy texture is lost. Thus is a bug in implementation of EnemyCleanupSystem. The player only receives the Fixture, not the entire Actor and thus the texture is lost. To be fixed later as out of scope
